### PR TITLE
feat: update build actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,10 +17,10 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Use Node.js 16
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: 16.x
 
@@ -36,7 +36,7 @@ jobs:
             - test
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   # Pulls all commits (needed for semantic release to correctly version)
                   # See https://github.com/semantic-release/semantic-release/issues/1526
@@ -48,7 +48,7 @@ jobs:
               run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
             - name: Use Node.js 16
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: 16.x
 
@@ -62,5 +62,5 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-              run: npx semantic-release
+              run: npx semantic-release^19
               working-directory: ./build


### PR DESCRIPTION
Update actions to ensure Node 16. 
Pin `semantic-release` to `v19`